### PR TITLE
Add install requires

### DIFF
--- a/devRequirements.txt
+++ b/devRequirements.txt
@@ -2,8 +2,8 @@ Django==1.10.1
 django-cors-headers==1.3.1
 django-filter==1.0.1
 djangorestframework==3.4.7
-DukeDSClient==0.2.14
+DukeDSClient==0.3.16
 mock==2.0.0
-PyJWT==1.4.2
-requests==2.11.1
-requests-oauthlib==0.7.0
+PyJWT==1.5.2
+requests==2.18.1
+requests-oauthlib==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+DukeDSClient==0.3.16
+PyJWT==1.5.2
+requests==2.18.1
+requests-oauthlib==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-DukeDSClient==0.3.16
-PyJWT==1.5.2
-requests==2.18.1
-requests-oauthlib==0.8.0

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,14 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='gcb-web-auth',
-    version='0.5',
+    version='0.5.1',
     packages=find_packages(),
+    install_requires=[
+        'DukeDSClient==0.3.16',
+        'PyJWT==1.5.2',
+        'requests==2.18.1',
+        'requests-oauthlib==0.8.0',
+    ],
     include_package_data=True,
     license='MIT License',
     description='Django app to integrate Duke OAuth for use in GCB.'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='gcb-web-auth',
-    version='0.5.1',
+    version='0.6',
     packages=find_packages(),
     install_requires=[
         'DukeDSClient==0.3.16',


### PR DESCRIPTION
- Updates dependency versions in devRequirements and adds necessary runtime requirements (DukeDSClient, PyJWT, requests, requests_oauthlib) to setup.py.
- For gcb-web-auth to work inside another django application, the packages in setup.py are required.
- Updates version to 0.6.

Fixes #16 