### PR TITLE
Avoid revoking prior tokens upon refresh

### DIFF
--- a/gcb_web_auth/tests_utils.py
+++ b/gcb_web_auth/tests_utils.py
@@ -85,7 +85,7 @@ class OAuthUtilsTest(TestCase):
         self.assertTrue(mock_make_oauth_session.post.called_with(self.service.resource_uri), 'Posts to resource URI')
 
     @patch('gcb_web_auth.utils.revoke_token')
-    def test_updates_existing_token_and_revokes(self, mock_revoke_token):
+    def test_updates_existing_token(self, mock_revoke_token):
         service = make_oauth_service(OAuthService, save=True)
         user = get_user_model().objects.create(username='user123')
         token_dict1 = {'access_token': 'aaaaa1'}
@@ -96,8 +96,7 @@ class OAuthUtilsTest(TestCase):
         t2_id, t2_token = t2.id, t2.token_dict
         self.assertEqual(t1_id, t2_id, 'Token should be updated with same id')
         self.assertNotEqual(t1_token, t2_token, 'Token data have been updated')
-        self.assertTrue(mock_revoke_token.called_with(t1), 'Should have revoked t1')
-        self.assertEqual(mock_revoke_token.call_count, 1, 'Should revoke once')
+        self.assertFalse(mock_revoke_token.called, 'Should not revoke any tokens')
 
     @patch('gcb_web_auth.utils.requests')
     def test_revoke_token(self, mock_client):

--- a/gcb_web_auth/utils.py
+++ b/gcb_web_auth/utils.py
@@ -105,17 +105,9 @@ class OAuthException(BaseException):
 
 
 def save_token(oauth_service, token_dict, user):
+    # If we already have an OAuthToken for this user, update it
     token, created = OAuthToken.objects.get_or_create(user=user,
                                                       service=oauth_service)
-    # If a token already existed we must revoke the old one
-    if not created:
-        try:
-            revoke_token(token)
-        except OAuthException as e:
-            logger.warn('Unable to revoke token, proceeding to save: {}'.format(e))
-        token.token_dict = {}
-        token.save()
-    # Either way, save the current token
     token.token_dict = token_dict
     token.save()
     return token


### PR DESCRIPTION
Revoking the token wasn't behaving as expected. I assumed this would revoke the credential that is no longer needed, but it disables the entire string of refreshed tokens.

This corrects our implementation of token refresh, and a configuration change on refresh token expiry time fixes our issue with not being able to refresh tokens after the initial 1 hour lifetime.

Fixes #19 and #10 