### PR TITLE
Helper functions for endpoints and DDS Config

### DIFF
--- a/gcb_web_auth/exceptions.py
+++ b/gcb_web_auth/exceptions.py
@@ -1,0 +1,19 @@
+
+class OAuthException(BaseException):
+    pass
+
+
+class NoTokenException(BaseException):
+    pass
+
+
+class ConfigurationException(BaseException):
+    pass
+
+
+class DDSConfigurationException(ConfigurationException):
+    pass
+
+
+class OAuthConfigurationException(ConfigurationException):
+    pass

--- a/gcb_web_auth/tests_utils.py
+++ b/gcb_web_auth/tests_utils.py
@@ -129,7 +129,7 @@ class OAuthTokenUtilTestCase(TestCase):
         DDSEndpoint.objects.create(api_root='', portal_root='', openid_provider_id='')
 
     @patch('gcb_web_auth.utils.check_jwt_token')
-    def gcb_web_auth(self, mock_check_jwt_token):
+    def test_gcb_web_auth(self, mock_check_jwt_token):
         mock_check_jwt_token.return_value = True
         local_token = get_local_dds_token(self.user)
         self.assertEqual(local_token.key, 'some-token', 'Should return token when check passes')

--- a/gcb_web_auth/utils.py
+++ b/gcb_web_auth/utils.py
@@ -6,9 +6,24 @@ from requests_oauthlib import OAuth2Session
 from gcb_web_auth.models import OAuthToken, OAuthService, DukeDSAPIToken, DDSEndpoint
 from jwt import decode, InvalidTokenError
 from django.core.exceptions import ObjectDoesNotExist
+from gcb_web_auth.exceptions import *
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def get_default_dds_endpoint():
+    endpoint = DDSEndpoint.objects.first()
+    if not endpoint:
+        raise DDSConfigurationException('No DDSEndpoint is configured')
+    return endpoint
+
+
+def get_default_oauth_service():
+    service = OAuthService.objects.first()
+    if not service:
+        raise OAuthConfigurationException('No OAuthService is configured')
+    return service
 
 
 def check_jwt_token(token):
@@ -100,10 +115,6 @@ def fetch_user_details(oauth_service, session):
         raise OAuthException(e)
 
 
-class OAuthException(BaseException):
-    pass
-
-
 def save_token(oauth_service, token_dict, user):
     # If we already have an OAuthToken for this user, update it
     token, created = OAuthToken.objects.get_or_create(user=user,
@@ -130,17 +141,13 @@ def revoke_token(token):
         raise OAuthException(e)
 
 
-class NoTokenException(BaseException):
-    pass
-
-
 def get_oauth_token(user):
     """
     Gets the OAuth token object for the specified user, and refreshes if needed
     :param user:
     :return:
     """
-    service = OAuthService.objects.first()
+    service = get_default_oauth_service()
     try:
         current_user_details(service, user)
     except OAuthException as e:
@@ -165,14 +172,13 @@ def get_local_dds_token(user):
 
     return None
 
-
 def get_dds_token_from_oauth(oauth_token):
     """
     Presents an OAuth token to DukeDS, obtaining an api_token
     :param oauth_token: An OAuthToken object
     :return: The dictionary from JSON returned by the /user/api_token endpoint
     """
-    endpoint = DDSEndpoint.objects.first()
+    endpoint = get_default_ddsendpoint()
     authentication_service_id = endpoint.openid_provider_id
     headers = {
         'Content-Type': ContentType.json,
@@ -239,7 +245,7 @@ def make_auth_config(token):
     :return: a ddsc.config.Config
     """
     config = Config()
-    endpoint = DDSEndpoint.objects.first()
+    endpoint = get_default_dds_endpoint()
     config.update_properties({
         Config.URL: endpoint.api_root,
     })
@@ -271,12 +277,32 @@ def remove_invalid_dukeds_tokens(user):
             token.delete()
 
 
-def load_dukeds_token(user):
-    return user.dukedsapitoken
+def create_config_for_endpoint(endpoint_cred):
+    """
+    Given a dds endpoint create ddsclient Config object filling in agent key and api root.
+    The returned config still requires user_key or auth to be filled in.
+    :param endpoint_cred: DDSEndpoint: endpoint to create agent and api root config
+    :return: ddsc.config.Config: settings to use with ddsclient
+    """
+    config = Config()
+    config.update_properties({'agent_key': endpoint_cred.agent_key})
+    config.update_properties({'url': endpoint_cred.api_root})
+    return config
+
+
+def get_dds_config_for_credentials(user_cred):
+    """
+    Given a DukeDS user credential object create complete Config for use with ddsc
+    :param user_cred: DDSUserCredential: user credential to create config based upon
+    :return: ddsc.config.Config: settings to use with ddsclient
+    """
+    config = create_config_for_endpoint(user_cred.endpoint)
+    config.update_properties({'user_key': user_cred.token})
+    return config
 
 
 def main():
-    duke_service = OAuthService.objects.first()
+    duke_service = get_default_oauth_service()
     auth_url, state = authorization_url(duke_service)
     print('Please go to {} and authorize access'.format(auth_url))
     authorization_response = raw_input('Enter the full callback URL: ')

--- a/gcb_web_auth/utils.py
+++ b/gcb_web_auth/utils.py
@@ -178,7 +178,7 @@ def get_dds_token_from_oauth(oauth_token):
     :param oauth_token: An OAuthToken object
     :return: The dictionary from JSON returned by the /user/api_token endpoint
     """
-    endpoint = get_default_ddsendpoint()
+    endpoint = get_default_dds_endpoint()
     authentication_service_id = endpoint.openid_provider_id
     headers = {
         'Content-Type': ContentType.json,

--- a/gcb_web_auth/utils.py
+++ b/gcb_web_auth/utils.py
@@ -13,6 +13,11 @@ logger = logging.getLogger(__name__)
 
 
 def get_default_dds_endpoint():
+    """
+    Get the default DDSEndpoint object, or raise DDSConfigurationException
+    if none found
+    :return: A DDSEndpoint object
+    """
     endpoint = DDSEndpoint.objects.first()
     if not endpoint:
         raise DDSConfigurationException('No DDSEndpoint is configured')
@@ -20,6 +25,11 @@ def get_default_dds_endpoint():
 
 
 def get_default_oauth_service():
+    """
+    Get the default OAuthService object, or raise OAuthConfigurationException
+    if none found
+    :return: An OAuthService object
+    """
     service = OAuthService.objects.first()
     if not service:
         raise OAuthConfigurationException('No OAuthService is configured')

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='gcb-web-auth',
-    version='0.9',
+    version='0.10',
     packages=find_packages(),
     install_requires=[
         'DukeDSClient==1.0.1',


### PR DESCRIPTION
Adds functions to utils to fetch default `DDSEndpoint` or `OAuthService` model objects, raising `DDSConfigurationException` or `OAuthConfigurationException` if none found `:

- `get_default_dds_endpoint()`
- `get_default_oauth_service()`

Migrates functions from [bespin-api](https://github.com/Duke-GCB/bespin-api/blob/8a30a4266ff8980bcc26c6236f40c2f7e2b74f17/data/util.py#L82-L142) to build DukeDSClient Config objects from a DDSEndpoint or DDSUserCredential

Updates version to 0.10