### PR TITLE
Add Circle step to upload PyPI release on tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - image: circleci/python:2.7
   release:
     docker:
-      - image: circleci/python3.6
+      - image: circleci/python:3.6
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ workflows:
       - test-2.7
   release:
     jobs:
-      - release
+      - release:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,16 @@ workflows:
     jobs:
       - test-3.6
       - test-2.7
+  release:
+    jobs:
+      - release
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - test-3.6
+            - test-2.7
+
 jobs:
   test-3.6: &test-template
     docker:
@@ -30,3 +40,16 @@ jobs:
     <<: *test-template
     docker:
       - image: circleci/python:2.7
+  release:
+    docker:
+      - image: circleci/python3.6
+    steps:
+      - checkout
+      - run:
+          command: |
+            virtualenv venv
+            source venv/bin/activate
+            pip install -r devRequirements.txt
+            pip install twine
+            python setup.py bdist_wheel --universal
+            twine upload --username "${PYPI_USERNAME}" --password "${PYPI_PASSWORD}" dist/*


### PR DESCRIPTION
Verified locally with the [CircleCI local CLI](https://circleci.com/docs/2.0/local-cli/) and `circleci build --job release`

Upon merge, I'll tag 1.0.0 for a release