### PR TITLE
Fix createddsendpoint command KeyError

### DIFF
--- a/gcb_web_auth/management/commands/createddsendpoint.py
+++ b/gcb_web_auth/management/commands/createddsendpoint.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
         fields = dict()
         for k in {'name','api_root','portal_root','agent_key','openid_provider_id', 'openid_provider_service_id'}:
             fields[k] = options[k]
-            endpoint = DDSEndpoint.objects.filter(name=fields['name'])
+        endpoint = DDSEndpoint.objects.filter(name=fields['name'])
         if endpoint:
             endpoint.update(**fields)
             endpoint = endpoint.first()

--- a/gcb_web_auth/test_createddsendpoint.py
+++ b/gcb_web_auth/test_createddsendpoint.py
@@ -1,0 +1,11 @@
+from django.test import TestCase
+from gcb_web_auth.management.commands.createddsendpoint import Command
+
+
+class CreateDDSEndpointTestCase(TestCase):
+    def test_createddsentpoint_handle(self):
+        cmd = Command()
+        cmd.handle(name='a', api_root='b', portal_root='c', agent_key='d', openid_provider_id='e',
+                   openid_provider_service_id='f')
+        cmd.handle(name='a', api_root='b', portal_root='c', agent_key='d', openid_provider_id='e',
+                   openid_provider_service_id='f')


### PR DESCRIPTION
This was only a problem with python 3 due to sorting of dictionary values.
Fixes code indenting so that we do not prematurely try to lookup the endpoint.

Fixes #41 