### PR TITLE
Upgrade DukeDSClient to 3.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,7 @@
 #
 # The test-and-release workflow runs the following jobs:
 # 1. test-3.6 - test tags and branches under Python 3.6
-# 2. test-2.7 - test tags and branches under Python 2.7
-# 3. release - after both test jobs succeed, upload to PyPi for tags (but not for branches).
+# 2. release - after both test jobs succeed, upload to PyPi for tags (but not for branches).
 #
 # Note that the test jobs have a tags filter. This is because the release job
 # (which depends on the test jobs and needs a tag filter) wouldn't run unless its dependencies
@@ -18,10 +17,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - test-2.7:
-          filters:
-            tags:
-              only: /.*/
       - release:
           filters:
             tags:
@@ -30,7 +25,6 @@ workflows:
               ignore: /.*/
           requires:
             - test-3.6
-            - test-2.7
 jobs:
   test-3.6: &test-template
     docker:
@@ -52,10 +46,6 @@ jobs:
           command: |
             source venv/bin/activate
             ./runtests.sh
-  test-2.7:
-    <<: *test-template
-    docker:
-      - image: circleci/python:2.7
   release:
     docker:
       - image: circleci/python:3.6

--- a/devRequirements.txt
+++ b/devRequirements.txt
@@ -5,7 +5,7 @@ django-cors-headers==1.3.1
 django-filter==1.0.1
 djangorestframework==3.9.1
 djangorestframework-jwt==1.11.0
-DukeDSClient==2.1.4
+DukeDSClient==3.0.0
 funcsigs==1.0.2
 future==0.16.0
 idna==2.5

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     version='1.1.2',
     packages=find_packages(),
     install_requires=[
-        'DukeDSClient==2.1.4',
+        'DukeDSClient==3.0.0',
         'PyJWT==1.5.2',
         'requests>=2.20.0',
         'requests-oauthlib==0.8.0',


### PR DESCRIPTION
Upgrades to the latest version of DukeDSClient. 
Removes python2 CI testing - python2 is EOL.
We are not using this library with python2 anywhere.