### PR TITLE
Require DukeDSClient >= 3.0.0 in dev

### DIFF
--- a/devRequirements.txt
+++ b/devRequirements.txt
@@ -5,7 +5,7 @@ django-cors-headers==1.3.1
 django-filter==1.0.1
 djangorestframework==3.11.2
 djangorestframework-jwt==1.11.0
-DukeDSClient==3.0.0
+DukeDSClient>=3.0.0
 funcsigs==1.0.2
 future==0.16.0
 idna==2.5


### PR DESCRIPTION
Makes devRequirements match setup.py for DukeDSClient requirement.
Fixes #47